### PR TITLE
Configure shared/jre/gwt project layout

### DIFF
--- a/gwt/pom.xml
+++ b/gwt/pom.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>pacman-parent</artifactId>
+        <groupId>com.github.alejandrocq</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>pacman-gwt</artifactId>
+</project>

--- a/jre/pom.xml
+++ b/jre/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>pacman-parent</artifactId>
+        <groupId>com.github.alejandrocq</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>pacman-jre</artifactId>
+
+    <properties>
+        <app.mainClass>pacman.jre.ComecocosFrame</app.mainClass>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.github.alejandrocq</groupId>
+            <artifactId>pacman-shared</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.4.0</version>
+                <configuration>
+                    <mainClass>${app.mainClass}</mainClass>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.6</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>${app.mainClass}</mainClass>
+                        </manifest>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/jre/src/main/java/pacman/jre/ComecocosFrame.java
+++ b/jre/src/main/java/pacman/jre/ComecocosFrame.java
@@ -1,4 +1,4 @@
-package guicomecocos;
+package pacman.jre;
 
 import static java.awt.EventQueue.invokeLater;
 

--- a/jre/src/main/java/pacman/jre/LaberintoFrame.java
+++ b/jre/src/main/java/pacman/jre/LaberintoFrame.java
@@ -1,12 +1,12 @@
-package guicomecocos;
+package pacman.jre;
 
-import static guicomecocos.LaberintoFrame.Modo.DIOS;
+import static pacman.jre.LaberintoFrame.Modo.DIOS;
 import static java.lang.Math.sin;
 
-import data.DatosComecocos;
-import data.Fantasma;
-import data.Mueve;
-import data.Rejilla;
+import pacman.shared.DatosComecocos;
+import pacman.shared.Fantasma;
+import pacman.shared.Mueve;
+import pacman.shared.Rejilla;
 import java.awt.Color;
 import java.awt.Graphics;
 import java.awt.event.KeyEvent;

--- a/jre/src/main/java/pacman/shared/DatosComecocos.java
+++ b/jre/src/main/java/pacman/shared/DatosComecocos.java
@@ -1,5 +1,5 @@
 
-package data;
+package pacman.shared;
 
 /**
  * Subclase de Personaje que representa al comecocos.

--- a/jre/src/main/java/pacman/shared/Fantasma.java
+++ b/jre/src/main/java/pacman/shared/Fantasma.java
@@ -1,5 +1,5 @@
 
-package data;
+package pacman.shared;
 
 /**
  * Subclase de Personaje que representa un fantasma.

--- a/jre/src/main/java/pacman/shared/Mueve.java
+++ b/jre/src/main/java/pacman/shared/Mueve.java
@@ -1,10 +1,10 @@
 
-package data;
+package pacman.shared;
 
 
-import guicomecocos.ComecocosFrame;
-import guicomecocos.LaberintoFrame;
-import guicomecocos.LaberintoFrame.Modo;
+import pacman.jre.ComecocosFrame;
+import pacman.jre.LaberintoFrame;
+import pacman.jre.LaberintoFrame.Modo;
 import javax.swing.JOptionPane;
 
 /**

--- a/jre/src/main/java/pacman/shared/Personaje.java
+++ b/jre/src/main/java/pacman/shared/Personaje.java
@@ -1,5 +1,5 @@
 
-package data;
+package pacman.shared;
 
 /**
  * Cada uno de los personajes del juego.

--- a/jre/src/main/java/pacman/shared/Rejilla.java
+++ b/jre/src/main/java/pacman/shared/Rejilla.java
@@ -1,5 +1,5 @@
 
-package data;
+package pacman.shared;
 
 /**
  * Contiene una matriz de caracteres que representa un laberinto.

--- a/pom.xml
+++ b/pom.xml
@@ -4,51 +4,22 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.alejandrocq</groupId>
-    <artifactId>pacman-java</artifactId>
+    <artifactId>pacman-parent</artifactId>
+    <packaging>pom</packaging>
     <version>1.0-SNAPSHOT</version>
 
     <url>https://github.com/alejandrocq/pacman-java</url>
+
+    <modules>
+        <module>gwt</module>
+        <module>jre</module>
+        <module>shared</module>
+    </modules>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <app.mainClass>guicomecocos.ComecocosFrame</app.mainClass>
     </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>1.4.0</version>
-                <configuration>
-                    <mainClass>${app.mainClass}</mainClass>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.6</version>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <mainClass>${app.mainClass}</mainClass>
-                        </manifest>
-                    </archive>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/shared/pom.xml
+++ b/shared/pom.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>pacman-parent</artifactId>
+        <groupId>com.github.alejandrocq</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>pacman-shared</artifactId>
+</project>


### PR DESCRIPTION
Veo que has creado pacman-gwt, esta bien! pero prefiero hacerlo todo en el mismo proyecto para que se vea mas claro como se comparte el código. He creado los 3 modulos, shared, jre y gwt. Los dos últimos deberá contener código específico de jre o gwt y en shared el código compartido entre los otros dos. Otra forma de verlo es que en shared metemos el motor del juego, y en jre/gwt metemos el código específico para la visualización en HTML y Nativo.

También he modificado los nombres de paquetes, es una cosa específica de GWT pero bueno, va simplificar y no lia mucho, simplemente respeta los paquetes pacman.jre, pacman.shared y pacman.gwt para cada modulo.
